### PR TITLE
Add PID controller

### DIFF
--- a/docs/pages/software/modules/pid.md
+++ b/docs/pages/software/modules/pid.md
@@ -1,0 +1,61 @@
+---
+title: Pid
+layout: default
+parent: Modules
+nav_order: 5
+---
+
+# Pid
+
+The `pid` module implements a **PID controller** used to keep a measured
+process value at a desired target. It drives pH and EC correction for the
+system: given a target pH and the current reading from the probe,
+it computes how much corrective action (dosing) should be applied.
+
+## Controller
+
+The controller is constructed with the three gains and is then driven by
+repeated calls to `calculate`, one per control cycle.
+
+| Parameter | Meaning |
+| --- | --- |
+| `current` | The latest measured value (e.g. current pH). |
+| `target` | The setpoint the controller drives towards. |
+| `millis` | A monotonic timestamp in **milliseconds**. |
+
+The return value is the control signal — the corrective action to apply, for
+example the dosing amount or pump duty. Its sign indicates direction: a
+positive output means the measured value is below the target and must be
+raised, a negative output means it is above and must be lowered.
+
+## The Three Terms
+
+On each call the controller computes the `error = target - current` and
+combines three terms:
+
+- **Proportional** (`kp * error`) — reacts to the present error. Larger error,
+  larger correction. Acts immediately but alone never fully settles on the
+  target.
+- **Integral** (`ki * integral`) — accumulates `error * dt` over time, so small
+  persistent offsets are eventually corrected.
+- **Derivative** (`kd * (error - last_error) / dt`) — reacts to how fast the
+  error is changing and dampens the approach, reducing overshoot.
+
+The sum of the three terms is the control signal.
+
+## Timing
+
+`dt` is derived from the difference between successive `millis` values, so the
+integral and derivative are correctly scaled by the real interval between
+control cycles. This keeps the tuning independent of how often the loop runs.
+
+{: .note}
+> Because `dt` is measured in **milliseconds**, the `ki` and `kd` gains are
+> scaled relative to a seconds-based time base. Expect `ki` in particular to be
+> a small value once tuned for a real system.
+
+{: .warning}
+> The first `calculate` call only seeds the internal state and returns the
+> proportional term — it does not feed the integral. This avoids a startup
+> spike from the initially unknown `dt`. If two calls share the same `millis`
+> (`dt == 0`), the derivative term is skipped to avoid a division by zero.

--- a/logic/src/lib.rs
+++ b/logic/src/lib.rs
@@ -3,4 +3,5 @@
 pub mod config;
 pub mod dhcp;
 pub mod dns;
+pub mod pid;
 pub mod wifi;

--- a/logic/src/pid.rs
+++ b/logic/src/pid.rs
@@ -1,0 +1,109 @@
+pub type Float = f64;
+
+pub struct PidController {
+    kp: Float,
+    ki: Float,
+    kd: Float,
+    integral: Float,
+    last_error: Float,
+    last_millis: usize,
+}
+
+impl PidController {
+    pub fn new(p: Float, i: Float, d: Float) -> Self {
+        Self {
+            kp: p,
+            ki: i,
+            kd: d,
+            integral: 0.0,
+            last_error: 0.0,
+            last_millis: 0,
+        }
+    }
+
+    pub fn calculate(&mut self, current: Float, target: Float, millis: usize) -> Float {
+        let dt = millis - self.last_millis;
+        let error = target - current;
+
+        let derivative = if dt > 0 {
+            (error - self.last_error) / dt as Float
+        } else {
+            0 as Float
+        };
+
+        self.last_error = error;
+
+        if self.last_millis == 0 {
+            self.last_millis = millis;
+            return self.kp * error;
+        }
+        self.last_millis = millis;
+
+        self.integral += error * dt as Float;
+
+        self.kp * error //proportional
+        + self.ki * self.integral //integral
+        + self.kd * derivative // derivative
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_first_call_no_spike() {
+        let mut controller = PidController::new(1.0, 1.0, 1.0);
+        let out = controller.calculate(2.0, 6.0, 40_000);
+        assert!(out < 20.0);
+    }
+
+    #[test]
+    fn test_two_concurrent_calculations() {
+        let mut controller = PidController::new(1.0, 1.0, 1.0);
+        controller.calculate(2.0, 6.0, 1000);
+        let out = controller.calculate(4.0, 6.0, 1000);
+        assert!(out.is_finite());
+    }
+
+    #[test]
+    fn test_only_proportional() {
+        let mut controller = PidController::new(0.5, 0.0, 0.0);
+        controller.calculate(2.0, 6.0, 1000);
+        let out = controller.calculate(4.0, 6.0, 2000);
+        assert_eq!(out, 1.0);
+    }
+
+    #[test]
+    fn test_only_proportional_direction() {
+        let mut controller = PidController::new(0.5, 0.0, 0.0);
+        let a = controller.calculate(2.0, 6.0, 1000);
+        let b = controller.calculate(10.0, 6.0, 2000);
+        assert!(a > b);
+    }
+
+    #[test]
+    fn test_only_integral() {
+        let mut controller = PidController::new(0.0, 0.5, 0.0);
+        controller.calculate(2.0, 6.0, 1000);
+        let a = controller.calculate(4.0, 6.0, 2000);
+        let b = controller.calculate(4.0, 6.0, 3000);
+        assert!(a < b);
+    }
+
+    #[test]
+    fn test_only_derivative_constant() {
+        let mut controller = PidController::new(0.0, 0.0, 0.5);
+        controller.calculate(2.0, 6.0, 1000);
+        let out = controller.calculate(2.0, 6.0, 2000);
+        assert_eq!(out, 0.0);
+    }
+
+    #[test]
+    fn test_only_derivative() {
+        let mut controller = PidController::new(0.0, 0.0, 0.5);
+        controller.calculate(2.0, 6.0, 1000);
+        let out = controller.calculate(3.0, 6.0, 2000);
+        assert!(out < 0.0);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR adds a PID module that contains a PID controller. It will eventually be used for dosing of ph and ec additives.

## Related issues

Closes #81 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have reviewed my own code
- [x] I have added tests where applicable
- [x] All existing tests pass
- [x] I have updated documentation if needed
