### PR TITLE
Add blackboard

### DIFF
--- a/cross/src/blackboard.rs
+++ b/cross/src/blackboard.rs
@@ -1,0 +1,12 @@
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+use logic::{Float, blackboard::Measurements};
+
+static MEASUREMENTS: Mutex<CriticalSectionRawMutex, Measurements> =
+    Mutex::new(Measurements::DEFAULT);
+
+pub async fn snapshot() -> Measurements {
+    MEASUREMENTS.lock().await.clone()
+}
+pub async fn set_ph(ph: Float) {
+    MEASUREMENTS.lock().await.ph = Some(ph)
+}

--- a/cross/src/lib.rs
+++ b/cross/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
 
+pub mod blackboard;
 pub mod dhcp;
 pub mod dns;
 pub mod partitions;

--- a/docs/pages/software/modules/blackboard.md
+++ b/docs/pages/software/modules/blackboard.md
@@ -1,0 +1,64 @@
+---
+title: Blackboard
+layout: default
+parent: Modules
+nav_order: 6
+---
+
+# Blackboard
+
+The blackboard is the shared, in-RAM store of plant-health **facts** — the
+latest measured values such as pH, EC, temperature and water level. It lets
+the many tasks that need this data read it from one place instead of passing
+data objects between them.
+
+---
+
+## Crate Split
+
+The blackboard is split across the two crates, the same way as the other
+modules:
+
+| Part | Lives in | Contents |
+| --- | --- | --- |
+| Data type (`Measurements`) | `logic` | a plain `no_std` struct of facts |
+| Store+accessors | `cross` | the `static` mutex and the read/write functions |
+
+Keeping the data type in `logic` means it has no dependency on the async
+runtime, so it stays host-testable. The shared `static` and its locking
+depend on `embassy-sync` and therefore live in `cross`.
+
+---
+
+## Access
+
+The store is a single `Mutex` over the whole struct, accessed through a small
+set of functions rather than the raw `static`:
+
+```rust
+static MEASUREMENTS: Mutex<CriticalSectionRawMutex, Measurements> =
+    Mutex::new(Measurements::DEFAULT);
+
+pub async fn snapshot() -> Measurements { MEASUREMENTS.lock().await.clone() }
+pub async fn set_ph(ph: Float) { MEASUREMENTS.lock().await.ph = ph }
+```
+
+A reader calls `snapshot()` to copy out a coherent view of all facts at once;
+a writer uses a field setter. Routing every access through these functions is
+what keeps the locking rules below in one place.
+
+---
+
+## Rules
+
+These conventions keep the shared state correct and contention-free:
+
+- **Single writer per field.** Each fact is written by exactly one task (the
+  task measuring that sensor) and only read by everyone else. This removes
+  write contention by design.
+- **Lock, copy, release — never across `.await`.** A critical section only
+  copies values out and returns; it must not hold the lock across an `await`,
+  which would block every other task.
+- **One mutex over the whole struct.** A single lock hands readers a
+  *consistent* multi-field snapshot. Per-field locks are unnecessary and would
+  tear that consistency.

--- a/logic/src/blackboard.rs
+++ b/logic/src/blackboard.rs
@@ -1,0 +1,10 @@
+use crate::Float;
+
+#[derive(Clone)]
+pub struct Measurements {
+    pub ph: Option<Float>,
+}
+
+impl Measurements {
+    pub const DEFAULT: Self = Self { ph: None };
+}

--- a/logic/src/lib.rs
+++ b/logic/src/lib.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(not(test), no_std)]
 
+pub mod blackboard;
 pub mod config;
 pub mod dhcp;
 pub mod dns;
 pub mod pid;
 pub mod wifi;
+
+pub type Float = f64;

--- a/logic/src/pid.rs
+++ b/logic/src/pid.rs
@@ -1,4 +1,4 @@
-pub type Float = f64;
+use crate::Float;
 
 pub struct PidController {
     kp: Float,


### PR DESCRIPTION
## What does this PR do?
This PR adds a blackboard module that holds facts about plant health. It is used to share state across other modules that control the environment. 

## Related issues

Closes #83 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have reviewed my own code
- [x] I have added tests where applicable
- [x] All existing tests pass
- [x] I have updated documentation if needed
