### PR TITLE
Add ph probe module

### DIFF
--- a/cross/src/bin/main.rs
+++ b/cross/src/bin/main.rs
@@ -11,7 +11,7 @@ use cross::{
     dhcp::dhcp_task,
     dns::dns_task,
     mk_static,
-    ph::{PhProbe, analog::AnalogPhProbe, correct_for_temperature},
+    ph::{PhProbe, analog::AnalogPhProbe},
     shared_flash::{SharedFlash, SharedFlashInterface},
     stepper::{Stepper, drv8833::Drv8833},
     storage::CredentialStorage,

--- a/cross/src/bin/main.rs
+++ b/cross/src/bin/main.rs
@@ -11,6 +11,7 @@ use cross::{
     dhcp::dhcp_task,
     dns::dns_task,
     mk_static,
+    ph::{PhProbe, analog::AnalogPhProbe, correct_for_temperature},
     shared_flash::{SharedFlash, SharedFlashInterface},
     stepper::{Stepper, drv8833::Drv8833},
     storage::CredentialStorage,
@@ -117,9 +118,14 @@ async fn main(spawner: Spawner) -> ! {
     let bin1 = Output::new(peripherals.GPIO20, Level::Low, OutputConfig::default());
     let bin2 = Output::new(peripherals.GPIO21, Level::Low, OutputConfig::default());
     let mut stepper = Drv8833::new(ain1, ain2, bin1, bin2, 200);
+    let _ = stepper.release().await;
+
+    let mut ph_probe = AnalogPhProbe::new(peripherals.ADC1, peripherals.GPIO0);
     loop {
-        let _ = stepper.move_steps(-2500).await;
-        let _ = stepper.release().await;
+        //let _ = stepper.move_steps(-2500).await;
+        let res = ph_probe.read().await.expect("ph probe should read");
+        let corrected = correct_for_temperature(res, 1.0);
+        info!("ph: {}", corrected);
         Timer::after(Duration::from_secs(5)).await;
     }
 }

--- a/cross/src/bin/main.rs
+++ b/cross/src/bin/main.rs
@@ -122,10 +122,9 @@ async fn main(spawner: Spawner) -> ! {
 
     let mut ph_probe = AnalogPhProbe::new(peripherals.ADC1, peripherals.GPIO0);
     loop {
-        //let _ = stepper.move_steps(-2500).await;
+        let _ = stepper.move_steps(-2500).await;
         let res = ph_probe.read().await.expect("ph probe should read");
-        let corrected = correct_for_temperature(res, 1.0);
-        info!("ph: {}", corrected);
+        info!("ph: {}", res);
         Timer::after(Duration::from_secs(5)).await;
     }
 }

--- a/cross/src/lib.rs
+++ b/cross/src/lib.rs
@@ -5,6 +5,7 @@ pub mod blackboard;
 pub mod dhcp;
 pub mod dns;
 pub mod partitions;
+pub mod ph;
 pub mod shared_flash;
 pub mod stepper;
 pub mod storage;

--- a/cross/src/ph.rs
+++ b/cross/src/ph.rs
@@ -6,10 +6,6 @@ pub trait PhProbe {
     async fn read(&mut self) -> Result<Float, Self::Error>;
 }
 
-pub fn correct_for_temperature(ph: Float, _temp: Float) -> Float {
-    ph
-}
-
 pub mod analog {
 
     use super::*;

--- a/cross/src/ph.rs
+++ b/cross/src/ph.rs
@@ -44,6 +44,7 @@ pub mod analog {
 
         async fn read(&mut self) -> Result<Float, Self::Error> {
             const SAMPLES: u32 = 16;
+            const VOLTAGE_DIVISOR: u32 = 2;
             let mut sum: u32 = 0;
             let mut min = u16::MAX;
             let mut max = 0;
@@ -54,7 +55,7 @@ pub mod analog {
                 max = max.max(v);
             }
             let avg = (sum - min as u32 - max as u32) / (SAMPLES - 2); //drop min and max to counteract spikes
-            Ok((avg * 2) as Float) //times two because of voltage divider
+            Ok((avg * VOLTAGE_DIVISOR) as Float) //times two because of voltage divider
         }
     }
 }

--- a/cross/src/ph.rs
+++ b/cross/src/ph.rs
@@ -43,7 +43,18 @@ pub mod analog {
         type Error = ();
 
         async fn read(&mut self) -> Result<Float, Self::Error> {
-            Ok(self.adc.read_oneshot(&mut self.pin).await as Float)
+            const SAMPLES: u32 = 16;
+            let mut sum: u32 = 0;
+            let mut min = u16::MAX;
+            let mut max = 0;
+            for _ in 0..SAMPLES {
+                let v = self.adc.read_oneshot(&mut self.pin).await;
+                sum += v as u32;
+                min = min.min(v);
+                max = max.max(v);
+            }
+            let avg = (sum - min as u32 - max as u32) / (SAMPLES - 2); //drop min and max to counteract spikes
+            Ok((avg * 2) as Float) //times two because of voltage divider
         }
     }
 }

--- a/cross/src/ph.rs
+++ b/cross/src/ph.rs
@@ -1,0 +1,49 @@
+use logic::Float;
+
+#[allow(async_fn_in_trait)]
+pub trait PhProbe {
+    type Error;
+    async fn read(&mut self) -> Result<Float, Self::Error>;
+}
+
+pub fn correct_for_temperature(ph: Float, _temp: Float) -> Float {
+    ph
+}
+
+pub mod analog {
+
+    use super::*;
+    use esp_hal::{
+        Async,
+        analog::adc::{Adc, AdcCalCurve, AdcChannel, AdcConfig, AdcPin},
+        gpio::AnalogPin,
+        peripherals::ADC1,
+    };
+
+    pub struct AnalogPhProbe<'a, PIN: AdcChannel> {
+        adc: Adc<'a, ADC1<'a>, Async>,
+        pin: AdcPin<PIN, ADC1<'a>, AdcCalCurve<ADC1<'a>>>,
+    }
+
+    impl<'a, PIN: AdcChannel + AnalogPin> AnalogPhProbe<'a, PIN> {
+        pub fn new(adc1: ADC1<'a>, input: PIN) -> Self {
+            let mut config = AdcConfig::new();
+            let pin = config.enable_pin_with_cal::<PIN, AdcCalCurve<ADC1<'a>>>(
+                input,
+                esp_hal::analog::adc::Attenuation::_11dB,
+            );
+            Self {
+                adc: Adc::new(adc1, config).into_async(),
+                pin,
+            }
+        }
+    }
+
+    impl<'a, PIN: AdcChannel + AnalogPin> PhProbe for AnalogPhProbe<'a, PIN> {
+        type Error = ();
+
+        async fn read(&mut self) -> Result<Float, Self::Error> {
+            Ok(self.adc.read_oneshot(&mut self.pin).await as Float)
+        }
+    }
+}

--- a/docs/pages/software/modules/ph.md
+++ b/docs/pages/software/modules/ph.md
@@ -1,0 +1,67 @@
+---
+title: Ph
+layout: default
+parent: Modules
+nav_order: 8
+---
+
+# Ph
+
+The `ph` module reads a pH probe. It defines a hardware-agnostic `PhProbe`
+trait and ships one implementation, `AnalogPhProbe`, that samples a probe's
+analog output through the ESP32-C3's ADC. The trait lets the rest of the system
+read pH without knowing how the probe is wired up.
+
+---
+
+## The `PhProbe` Trait
+
+`PhProbe` is the abstraction every probe implements:
+
+| Method | Meaning |
+| --- | --- |
+| `read()` | Take a reading. `async`, fallible (`Result<Float, Self::Error>`). |
+
+`read` is `async` so that probes talking to a chip over a bus can `await` their
+I/O; the analog implementation drives the ADC and resolves once the conversion
+completes.
+
+---
+
+## `AnalogPhProbe`
+
+The analog probe is built from the `ADC1` peripheral and the GPIO carrying the
+probe's analog output:
+
+```rust
+let mut probe = AnalogPhProbe::new(peripherals.ADC1, peripherals.GPIO0);
+```
+
+On the ESP32-C3, `GPIO0` is `ADC1` channel 0. The pin is enabled at **11 dB
+attenuation** so the ADC covers the widest input range the chip offers.
+
+### Calibration
+
+The pin is enabled with the **`AdcCalCurve`** calibration scheme:
+
+```rust
+config.enable_pin_with_cal::<PIN, AdcCalCurve<ADC1>>(input, Attenuation::_11dB);
+```
+
+This is not optional polish — it is required for correct readings. The
+calibration scheme sets the ADC's zero-bias init code from the chip's eFuse and
+returns the result in **millivolts** via curve fitting.
+
+### Sampling
+
+`read` does not return a single conversion. It takes **16 samples**, discards
+the single highest and lowest, and averages the remaining 14:
+
+```rust
+let avg = (sum - min - max) / (SAMPLES - 2);
+```
+
+Averaging cuts the ADC's random noise by roughly `√N`, and dropping the
+extremes rejects the occasional outlier spike — most visible while Wi-Fi is
+transmitting, which couples noise into the ADC. pH changes slowly, so the cost
+of 16 conversions per reading is irrelevant.


### PR DESCRIPTION
## What does this PR do?
This PR adds a ph module that contains the drivers for different kinds of ph probes. Currently only an analog probe is implemented.

## Related issues

Closes #88 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have reviewed my own code
- [x] I have added tests where applicable
- [x] All existing tests pass
- [x] I have updated documentation if needed
