### PR TITLE
Add calibration module

### DIFF
--- a/docs/pages/software/modules/calibration.md
+++ b/docs/pages/software/modules/calibration.md
@@ -1,0 +1,30 @@
+---
+title: Calibration
+layout: default
+parent: Modules
+nav_order: 9
+---
+
+# Calibration
+
+The `calibration` module provides `Linear`, a two-point linear calibration
+for translating a raw sensor reading into a calibrated value (e.g. converting
+a raw pH probe voltage into an actual pH value).
+
+## Usage
+
+A `Linear` is created empty and calibrated with two `Point { x, y }` readings,
+where `x` is the raw input and `y` is the known reference value:
+
+```rust
+let mut linear = Linear::new();
+linear.calibrate(
+    Point { x: raw_low, y: reference_low },
+    Point { x: raw_high, y: reference_high },
+)?;
+
+let calibrated = linear.apply(raw_reading)?;
+```
+
+`calibrate` fits the line `y = m*x + t` through the two points. `apply` then
+maps any raw `x` through that line.

--- a/logic/src/calibration.rs
+++ b/logic/src/calibration.rs
@@ -1,0 +1,12 @@
+use crate::Float;
+
+pub struct Linear {
+    m: Option<Float>,
+    t: Option<Float>,
+}
+
+impl Linear {
+    pub fn new() -> Self {
+        Self { m: None, t: None }
+    }
+}

--- a/logic/src/calibration.rs
+++ b/logic/src/calibration.rs
@@ -1,5 +1,11 @@
 use crate::Float;
 
+#[derive(Clone, Copy)]
+pub struct Point {
+    pub x: Float,
+    pub y: Float,
+}
+
 pub struct Linear {
     m: Option<Float>,
     t: Option<Float>,
@@ -8,5 +14,53 @@ pub struct Linear {
 impl Linear {
     pub fn new() -> Self {
         Self { m: None, t: None }
+    }
+
+    pub fn calibrate(&mut self, first: Point, second: Point) -> Result<(), ()> {
+        if second.x == first.x {
+            return Err(());
+        }
+        let m = (second.y - first.y) / (second.x - first.x);
+        self.t = Some(first.y - m * first.x);
+        self.m = Some(m);
+        return Ok(());
+    }
+
+    pub fn apply(&self, x: Float) -> Result<Float, ()> {
+        if let Some((m, t)) = self.m.zip(self.t) {
+            return Ok(m * x + t);
+        }
+        Err(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_calibrate_same_x_errors() {
+        let mut linear = Linear::new();
+        let first = Point { x: 1.0, y: 0.0 };
+        let second = Point { x: 1.0, y: 5.0 };
+        assert_eq!(linear.calibrate(first, second), Err(()));
+    }
+
+    #[test]
+    fn test_apply_before_calibrate_errors() {
+        let linear = Linear::new();
+        assert_eq!(linear.apply(1.0), Err(()));
+    }
+
+    #[test]
+    fn test_calibrate_and_apply() {
+        let mut linear = Linear::new();
+        let first = Point { x: 0.0, y: 0.0 };
+        let second = Point { x: 2.0, y: 4.0 };
+        assert_eq!(linear.calibrate(first, second), Ok(()));
+
+        assert_eq!(linear.apply(0.0).unwrap(), 0.0);
+        assert_eq!(linear.apply(2.0).unwrap(), 4.0);
+        assert_eq!(linear.apply(1.0).unwrap(), 2.0);
     }
 }

--- a/logic/src/lib.rs
+++ b/logic/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(test), no_std)]
 
 pub mod blackboard;
+pub mod calibration;
 pub mod config;
 pub mod dhcp;
 pub mod dns;


### PR DESCRIPTION
## What does this PR do?
This PR adds the calibration module, it is used to transform measured voltages from the ph and ec probe to a usable value.

## Related issues

Closes #86 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have reviewed my own code
- [x] I have added tests where applicable
- [x] All existing tests pass
- [x] I have updated documentation if needed
